### PR TITLE
Add event management tool modules

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -1,0 +1,26 @@
+"""Analytics and reporting."""
+
+from data_store import events, guests, rsvps, payments, seating_plans
+
+
+def dashboard_overview(event_id: int) -> dict:
+    """Return a simple overview for an event."""
+    total_guests = len(guests)
+    responses = {"Ja": 0, "Nein": 0, "Vielleicht": 0}
+    for (e_id, _), resp in rsvps.items():
+        if e_id == event_id:
+            responses[resp] += 1
+    paid = sum(1 for (g_id, e_id), status in [((g, e), p["status"]) for g, ev in payments.items() for e, p in ev.items()] if e_id == event_id and status == "paid")
+    return {
+        "total_guests": total_guests,
+        "responses": responses,
+        "payments": paid,
+    }
+
+
+def generate_report(event_id: int) -> dict:
+    """Generate a detailed report."""
+    overview = dashboard_overview(event_id)
+    seats = seating_plans.get(event_id, {})
+    overview["seats_assigned"] = sum(1 for s in seats.values() if s is not None)
+    return overview

--- a/communication.py
+++ b/communication.py
@@ -1,0 +1,32 @@
+"""Communication utilities."""
+
+from data_store import guests
+
+
+def send_message(recipient_ids, subject: str, body: str) -> None:
+    """Send a message to recipients (mock)."""
+    if recipient_ids == "all":
+        recipients = guests.values()
+    else:
+        recipients = [guests.get(gid) for gid in recipient_ids if gid in guests]
+    for r in recipients:
+        print(f"To {r['email']}: {subject}\n{body}\n")
+
+
+def push_notification(guest_id: int, message: str) -> bool:
+    """Send a push notification (mock)."""
+    guest = guests.get(guest_id)
+    if not guest:
+        return False
+    print(f"Push to {guest['name']}: {message}")
+    return True
+
+
+def send_reminder(event_id: int, guest_id: int = None) -> None:
+    """Send reminder emails. If guest_id is None, send to all."""
+    if guest_id:
+        target_ids = [guest_id] if guest_id in guests else []
+    else:
+        target_ids = list(guests.keys())
+    for gid in target_ids:
+        print(f"Reminder sent to {guests[gid]['email']} for event {event_id}")

--- a/data_store.py
+++ b/data_store.py
@@ -1,0 +1,24 @@
+"""In-memory data storage for the event management tool."""
+
+# Event data keyed by event_id
+events = {}
+
+# Guest data keyed by guest_id
+# Each guest is a dict with keys: name, email, category
+guests = {}
+
+# RSVP responses keyed by (event_id, guest_id)
+rsvps = {}
+
+# Seating plans keyed by event_id, values are dict seat_id -> guest_id
+seating_plans = {}
+
+# Payments keyed by guest_id
+# value: dict(event_id -> status)
+payments = {}
+
+# Feedback keyed by (event_id, guest_id)
+feedback = {}
+
+# Offline cache keyed by user_id
+offline_cache = {}

--- a/events.py
+++ b/events.py
@@ -1,0 +1,36 @@
+"""Event management functions."""
+
+from typing import List, Dict
+from data_store import events
+
+next_event_id = 1
+
+
+def create_event(name: str, date: str, time: str, location: str, price: float,
+                 program_points: List[str]) -> int:
+    """Create a new event and return its id."""
+    global next_event_id
+    event_id = next_event_id
+    next_event_id += 1
+    events[event_id] = {
+        "name": name,
+        "date": date,
+        "time": time,
+        "location": location,
+        "price": price,
+        "program": program_points,
+    }
+    return event_id
+
+
+def update_event(event_id: int, **changes) -> bool:
+    """Update fields of an existing event."""
+    if event_id not in events:
+        return False
+    events[event_id].update(changes)
+    return True
+
+
+def delete_event(event_id: int) -> bool:
+    """Delete an event by its id."""
+    return events.pop(event_id, None) is not None

--- a/feedback.py
+++ b/feedback.py
@@ -1,0 +1,13 @@
+"""Feedback and surveys."""
+
+from data_store import feedback
+
+
+def submit_feedback(event_id: int, guest_id: int, rating: int, comment: str) -> None:
+    """Store feedback from a guest."""
+    feedback[(event_id, guest_id)] = {"rating": rating, "comment": comment}
+
+
+def track_survey(event_id: int, question: str, answers: dict) -> dict:
+    """Return survey data for analysis (mock)."""
+    return {"event_id": event_id, "question": question, "answers": answers}

--- a/guests.py
+++ b/guests.py
@@ -1,0 +1,44 @@
+"""Guest list management."""
+
+import csv
+from typing import Dict
+from data_store import guests
+
+next_guest_id = 1
+
+
+def manage_guest(guest_id: int = None, action: str = "add", **data) -> int:
+    """Add, update or delete a guest."""
+    global next_guest_id
+    if action == "add":
+        gid = next_guest_id
+        next_guest_id += 1
+        guests[gid] = {"name": data.get("name"), "email": data.get("email"), "category": data.get("category")}
+        return gid
+    elif action == "edit" and guest_id in guests:
+        guests[guest_id].update(data)
+        return guest_id
+    elif action == "delete" and guest_id in guests:
+        del guests[guest_id]
+        return guest_id
+    else:
+        raise ValueError("Invalid action or guest_id")
+
+
+def categorize_guest(guest_id: int, category: str) -> bool:
+    """Assign a category to a guest."""
+    if guest_id not in guests:
+        return False
+    guests[guest_id]["category"] = category
+    return True
+
+
+def import_guestlist(csv_file: str) -> int:
+    """Import guests from a CSV file. Columns: name,email,category"""
+    count = 0
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            manage_guest(action="add", name=row.get("name"), email=row.get("email"), category=row.get("category"))
+            count += 1
+    return count

--- a/invitations.py
+++ b/invitations.py
@@ -1,0 +1,28 @@
+"""Invitation and RSVP handling."""
+
+from data_store import events, guests, rsvps
+
+
+def send_invitation(event_id: int, guest_email: str) -> bool:
+    """Mock sending an invitation by email."""
+    event = events.get(event_id)
+    if not event:
+        return False
+    print(f"Sending invitation for '{event['name']}' to {guest_email}")
+    return True
+
+
+def record_rsvp(event_id: int, guest_id: int, response: str) -> bool:
+    """Record a guest's RSVP response."""
+    if response not in {"Ja", "Nein", "Vielleicht"}:
+        raise ValueError("Response must be 'Ja', 'Nein' or 'Vielleicht'")
+    rsvps[(event_id, guest_id)] = response
+    return True
+
+
+def notify_organizer_rsvp(event_id: int, guest_id: int, response: str) -> None:
+    """Notify organizer about a new RSVP."""
+    event = events.get(event_id)
+    guest = guests.get(guest_id)
+    if event and guest:
+        print(f"Organizer notified: {guest['name']} responded '{response}' for '{event['name']}'")

--- a/mobile_apps.py
+++ b/mobile_apps.py
@@ -1,0 +1,16 @@
+"""Mobile app build placeholders."""
+
+
+def build_ios_app() -> None:
+    """Simulate building the iOS app."""
+    print("Building iOS app...")
+
+
+def build_android_app() -> None:
+    """Simulate building the Android app."""
+    print("Building Android app...")
+
+
+def sync_web_mobile(data: dict) -> None:
+    """Simulate syncing data between web and mobile."""
+    print(f"Syncing data: {data}")

--- a/offline.py
+++ b/offline.py
@@ -1,0 +1,15 @@
+"""Offline data handling."""
+
+from data_store import offline_cache
+
+
+def cache_offline_data(user_id: int, data: dict) -> None:
+    """Cache data for offline use."""
+    offline_cache.setdefault(user_id, {}).update(data)
+
+
+def sync_offline_data(user_id: int) -> dict:
+    """Return cached data and clear it to simulate sync."""
+    data = offline_cache.get(user_id, {})
+    offline_cache[user_id] = {}
+    return data

--- a/payments.py
+++ b/payments.py
@@ -1,0 +1,17 @@
+"""Payment processing (mock)."""
+
+from data_store import payments
+
+
+def process_payment(guest_id: int, event_id: int, amount: float, method: str) -> None:
+    """Record a payment for a guest."""
+    payments.setdefault(guest_id, {})[event_id] = {
+        "amount": amount,
+        "method": method,
+        "status": "paid",
+    }
+
+
+def payment_status(guest_id: int, event_id: int) -> str:
+    """Return payment status for a guest."""
+    return payments.get(guest_id, {}).get(event_id, {}).get("status", "unpaid")

--- a/seating.py
+++ b/seating.py
@@ -1,0 +1,26 @@
+"""Seating plan management."""
+
+from data_store import seating_plans
+
+
+def create_seating_plan(event_id: int, seats: int) -> None:
+    """Initialize a seating plan with a given number of seats."""
+    seating_plans[event_id] = {f"S{n}": None for n in range(1, seats + 1)}
+
+
+def select_seat(event_id: int, guest_id: int, seat_id: str) -> bool:
+    """Guest selects a seat if available."""
+    plan = seating_plans.get(event_id)
+    if not plan or seat_id not in plan or plan[seat_id] is not None:
+        return False
+    plan[seat_id] = guest_id
+    return True
+
+
+def assign_seat_manually(event_id: int, guest_id: int, seat_id: str) -> bool:
+    """Organizer assigns a seat, overwriting existing assignment."""
+    plan = seating_plans.get(event_id)
+    if not plan or seat_id not in plan:
+        return False
+    plan[seat_id] = guest_id
+    return True

--- a/security.py
+++ b/security.py
@@ -1,0 +1,12 @@
+"""Security utilities."""
+
+
+def ensure_gdpr_compliance(data: dict) -> bool:
+    """Placeholder GDPR compliance check."""
+    required = {"consent": True}
+    return all(data.get(k) == v for k, v in required.items())
+
+
+def enable_two_factor_auth(user_id: int) -> None:
+    """Mock enabling of 2FA."""
+    print(f"2FA enabled for user {user_id}")


### PR DESCRIPTION
## Summary
- add in-memory data store and modules for events, invitations/RSVPs, seating, guests, communication, payments, analytics, feedback, offline data, security, and mobile placeholders

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_689770d4ee4c8325a1916272dde5636d