### PR TITLE
Add basic Flask app and frontend for events

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Event Manager</title>
+    <title>Analytics - Event Manager</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -11,12 +11,13 @@
         <div class="nav-links">
             <a href="events.html">Events</a>
             <a href="guests.html">Guests</a>
-            <a href="analytics.html">Analytics</a>
+            <a href="analytics.html" class="active">Analytics</a>
         </div>
     </nav>
     <main class="container">
-        <h1>Welcome</h1>
-        <p>Use the navigation above to manage events and guests or to view analytics.</p>
+        <h1>Analytics</h1>
+        <div id="summary" class="card"></div>
     </main>
+    <script src="analytics.js"></script>
 </body>
 </html>

--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,9 @@
+async function loadSummary() {
+  const res = await fetch('/api/analytics');
+  const data = await res.json();
+  const div = document.getElementById('summary');
+  div.innerHTML = `<p><strong>Events:</strong> ${data.events}</p>` +
+                  `<p><strong>Guests:</strong> ${data.guests}</p>`;
+}
+
+loadSummary();

--- a/analytics.py
+++ b/analytics.py
@@ -1,0 +1,26 @@
+"""Analytics and reporting."""
+
+from data_store import events, guests, rsvps, payments, seating_plans
+
+
+def dashboard_overview(event_id: int) -> dict:
+    """Return a simple overview for an event."""
+    total_guests = len(guests)
+    responses = {"Ja": 0, "Nein": 0, "Vielleicht": 0}
+    for (e_id, _), resp in rsvps.items():
+        if e_id == event_id:
+            responses[resp] += 1
+    paid = sum(1 for (g_id, e_id), status in [((g, e), p["status"]) for g, ev in payments.items() for e, p in ev.items()] if e_id == event_id and status == "paid")
+    return {
+        "total_guests": total_guests,
+        "responses": responses,
+        "payments": paid,
+    }
+
+
+def generate_report(event_id: int) -> dict:
+    """Generate a detailed report."""
+    overview = dashboard_overview(event_id)
+    seats = seating_plans.get(event_id, {})
+    overview["seats_assigned"] = sum(1 for s in seats.values() if s is not None)
+    return overview

--- a/app.py
+++ b/app.py
@@ -1,0 +1,86 @@
+from flask import Flask, request, jsonify, send_from_directory
+from events import create_event, update_event, delete_event
+from guests import manage_guest
+from data_store import events, guests
+
+app = Flask(__name__, static_url_path='', static_folder='.')
+
+
+@app.route('/')
+def index():
+    """Serve the main HTML page."""
+    return send_from_directory('.', 'index.html')
+
+
+@app.route('/api/events', methods=['GET'])
+def list_events():
+    """Return all events."""
+    return jsonify(events)
+
+
+@app.route('/api/events', methods=['POST'])
+def add_event():
+    """Create an event from posted JSON."""
+    data = request.get_json(force=True)
+    event_id = create_event(
+        data.get('name', ''),
+        data.get('date', ''),
+        data.get('time', ''),
+        data.get('location', ''),
+        float(data.get('price', 0)),
+        data.get('program', [])
+    )
+    return jsonify({'id': event_id}), 201
+
+
+@app.route('/api/events/<int:event_id>', methods=['PUT'])
+def edit_event(event_id: int):
+    """Update an existing event."""
+    if not update_event(event_id, **request.get_json(force=True)):
+        return jsonify({'error': 'not found'}), 404
+    return jsonify(events[event_id])
+
+
+@app.route('/api/events/<int:event_id>', methods=['DELETE'])
+def remove_event(event_id: int):
+    """Delete the specified event."""
+    if not delete_event(event_id):
+        return jsonify({'error': 'not found'}), 404
+    return '', 204
+
+
+@app.route('/api/guests', methods=['GET'])
+def list_guests():
+    """Return all guests."""
+    return jsonify(guests)
+
+
+@app.route('/api/guests', methods=['POST'])
+def add_guest():
+    """Add a guest."""
+    data = request.get_json(force=True)
+    gid = manage_guest(action='add',
+                       name=data.get('name', ''),
+                       email=data.get('email', ''),
+                       category=data.get('category', ''))
+    return jsonify({'id': gid}), 201
+
+
+@app.route('/api/guests/<int:guest_id>', methods=['DELETE'])
+def delete_guest(guest_id: int):
+    """Delete a guest."""
+    try:
+        manage_guest(guest_id, action='delete')
+        return '', 204
+    except ValueError:
+        return jsonify({'error': 'not found'}), 404
+
+
+@app.route('/api/analytics', methods=['GET'])
+def analytics_summary():
+    """Simple analytics overview."""
+    return jsonify({'events': len(events), 'guests': len(guests)})
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/communication.py
+++ b/communication.py
@@ -1,0 +1,32 @@
+"""Communication utilities."""
+
+from data_store import guests
+
+
+def send_message(recipient_ids, subject: str, body: str) -> None:
+    """Send a message to recipients (mock)."""
+    if recipient_ids == "all":
+        recipients = guests.values()
+    else:
+        recipients = [guests.get(gid) for gid in recipient_ids if gid in guests]
+    for r in recipients:
+        print(f"To {r['email']}: {subject}\n{body}\n")
+
+
+def push_notification(guest_id: int, message: str) -> bool:
+    """Send a push notification (mock)."""
+    guest = guests.get(guest_id)
+    if not guest:
+        return False
+    print(f"Push to {guest['name']}: {message}")
+    return True
+
+
+def send_reminder(event_id: int, guest_id: int = None) -> None:
+    """Send reminder emails. If guest_id is None, send to all."""
+    if guest_id:
+        target_ids = [guest_id] if guest_id in guests else []
+    else:
+        target_ids = list(guests.keys())
+    for gid in target_ids:
+        print(f"Reminder sent to {guests[gid]['email']} for event {event_id}")

--- a/data_store.py
+++ b/data_store.py
@@ -1,0 +1,24 @@
+"""In-memory data storage for the event management tool."""
+
+# Event data keyed by event_id
+events = {}
+
+# Guest data keyed by guest_id
+# Each guest is a dict with keys: name, email, category
+guests = {}
+
+# RSVP responses keyed by (event_id, guest_id)
+rsvps = {}
+
+# Seating plans keyed by event_id, values are dict seat_id -> guest_id
+seating_plans = {}
+
+# Payments keyed by guest_id
+# value: dict(event_id -> status)
+payments = {}
+
+# Feedback keyed by (event_id, guest_id)
+feedback = {}
+
+# Offline cache keyed by user_id
+offline_cache = {}

--- a/events.html
+++ b/events.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Events - Event Manager</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="nav">
+        <a href="index.html" class="nav-brand">Event Manager</a>
+        <div class="nav-links">
+            <a href="events.html" class="active">Events</a>
+            <a href="guests.html">Guests</a>
+            <a href="analytics.html">Analytics</a>
+        </div>
+    </nav>
+    <main class="container">
+        <h1>Events</h1>
+        <form id="event-form" class="card">
+            <div class="form-row">
+                <input type="text" id="name" placeholder="Event Name" required>
+                <input type="date" id="date" required>
+                <input type="time" id="time" required>
+            </div>
+            <div class="form-row">
+                <input type="text" id="location" placeholder="Location" required>
+                <input type="number" id="price" placeholder="Price" step="0.01">
+                <input type="text" id="program" placeholder="Program (comma separated)">
+            </div>
+            <button type="submit" class="btn">Create Event</button>
+        </form>
+        <table id="events-table" class="table">
+            <thead>
+                <tr>
+                    <th>Name</th><th>Date</th><th>Time</th><th>Location</th><th>Price</th><th>Program</th><th></th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </main>
+    <script src="events.js"></script>
+</body>
+</html>

--- a/events.js
+++ b/events.js
@@ -1,0 +1,47 @@
+async function fetchEvents() {
+  const res = await fetch('/api/events');
+  const data = await res.json();
+  const tbody = document.querySelector('#events-table tbody');
+  tbody.innerHTML = '';
+  Object.entries(data).forEach(([id, ev]) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${ev.name}</td>
+      <td>${ev.date}</td>
+      <td>${ev.time}</td>
+      <td>${ev.location}</td>
+      <td>${Number(ev.price).toFixed(2)}</td>
+      <td>${(ev.program || []).join(', ')}</td>
+      <td><button data-id="${id}" class="btn btn-delete">Delete</button></td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+document.getElementById('event-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const payload = {
+    name: document.getElementById('name').value,
+    date: document.getElementById('date').value,
+    time: document.getElementById('time').value,
+    location: document.getElementById('location').value,
+    price: parseFloat(document.getElementById('price').value || 0),
+    program: document.getElementById('program').value.split(',').map(p => p.trim()).filter(Boolean)
+  };
+  await fetch('/api/events', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  });
+  e.target.reset();
+  fetchEvents();
+});
+
+document.querySelector('#events-table').addEventListener('click', async (e) => {
+  if (e.target.classList.contains('btn-delete')) {
+    const id = e.target.getAttribute('data-id');
+    await fetch(`/api/events/${id}`, {method: 'DELETE'});
+    fetchEvents();
+  }
+});
+
+fetchEvents();

--- a/events.py
+++ b/events.py
@@ -1,0 +1,36 @@
+"""Event management functions."""
+
+from typing import List, Dict
+from data_store import events
+
+next_event_id = 1
+
+
+def create_event(name: str, date: str, time: str, location: str, price: float,
+                 program_points: List[str]) -> int:
+    """Create a new event and return its id."""
+    global next_event_id
+    event_id = next_event_id
+    next_event_id += 1
+    events[event_id] = {
+        "name": name,
+        "date": date,
+        "time": time,
+        "location": location,
+        "price": price,
+        "program": program_points,
+    }
+    return event_id
+
+
+def update_event(event_id: int, **changes) -> bool:
+    """Update fields of an existing event."""
+    if event_id not in events:
+        return False
+    events[event_id].update(changes)
+    return True
+
+
+def delete_event(event_id: int) -> bool:
+    """Delete an event by its id."""
+    return events.pop(event_id, None) is not None

--- a/feedback.py
+++ b/feedback.py
@@ -1,0 +1,13 @@
+"""Feedback and surveys."""
+
+from data_store import feedback
+
+
+def submit_feedback(event_id: int, guest_id: int, rating: int, comment: str) -> None:
+    """Store feedback from a guest."""
+    feedback[(event_id, guest_id)] = {"rating": rating, "comment": comment}
+
+
+def track_survey(event_id: int, question: str, answers: dict) -> dict:
+    """Return survey data for analysis (mock)."""
+    return {"event_id": event_id, "question": question, "answers": answers}

--- a/guests.html
+++ b/guests.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Guests - Event Manager</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="nav">
+        <a href="index.html" class="nav-brand">Event Manager</a>
+        <div class="nav-links">
+            <a href="events.html">Events</a>
+            <a href="guests.html" class="active">Guests</a>
+            <a href="analytics.html">Analytics</a>
+        </div>
+    </nav>
+    <main class="container">
+        <h1>Guests</h1>
+        <form id="guest-form" class="card">
+            <div class="form-row">
+                <input type="text" id="g-name" placeholder="Name" required>
+                <input type="email" id="g-email" placeholder="Email" required>
+                <input type="text" id="g-category" placeholder="Category">
+            </div>
+            <button type="submit" class="btn">Add Guest</button>
+        </form>
+        <table id="guests-table" class="table">
+            <thead>
+                <tr>
+                    <th>Name</th><th>Email</th><th>Category</th><th></th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </main>
+    <script src="guests.js"></script>
+</body>
+</html>

--- a/guests.js
+++ b/guests.js
@@ -1,0 +1,41 @@
+async function fetchGuests() {
+  const res = await fetch('/api/guests');
+  const data = await res.json();
+  const tbody = document.querySelector('#guests-table tbody');
+  tbody.innerHTML = '';
+  Object.entries(data).forEach(([id, g]) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${g.name}</td>
+      <td>${g.email}</td>
+      <td>${g.category || ''}</td>
+      <td><button data-id="${id}" class="btn btn-delete">Delete</button></td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+document.getElementById('guest-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const payload = {
+    name: document.getElementById('g-name').value,
+    email: document.getElementById('g-email').value,
+    category: document.getElementById('g-category').value
+  };
+  await fetch('/api/guests', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  });
+  e.target.reset();
+  fetchGuests();
+});
+
+document.querySelector('#guests-table').addEventListener('click', async (e) => {
+  if (e.target.classList.contains('btn-delete')) {
+    const id = e.target.getAttribute('data-id');
+    await fetch(`/api/guests/${id}`, {method: 'DELETE'});
+    fetchGuests();
+  }
+});
+
+fetchGuests();

--- a/guests.py
+++ b/guests.py
@@ -1,0 +1,44 @@
+"""Guest list management."""
+
+import csv
+from typing import Dict
+from data_store import guests
+
+next_guest_id = 1
+
+
+def manage_guest(guest_id: int = None, action: str = "add", **data) -> int:
+    """Add, update or delete a guest."""
+    global next_guest_id
+    if action == "add":
+        gid = next_guest_id
+        next_guest_id += 1
+        guests[gid] = {"name": data.get("name"), "email": data.get("email"), "category": data.get("category")}
+        return gid
+    elif action == "edit" and guest_id in guests:
+        guests[guest_id].update(data)
+        return guest_id
+    elif action == "delete" and guest_id in guests:
+        del guests[guest_id]
+        return guest_id
+    else:
+        raise ValueError("Invalid action or guest_id")
+
+
+def categorize_guest(guest_id: int, category: str) -> bool:
+    """Assign a category to a guest."""
+    if guest_id not in guests:
+        return False
+    guests[guest_id]["category"] = category
+    return True
+
+
+def import_guestlist(csv_file: str) -> int:
+    """Import guests from a CSV file. Columns: name,email,category"""
+    count = 0
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            manage_guest(action="add", name=row.get("name"), email=row.get("email"), category=row.get("category"))
+            count += 1
+    return count

--- a/invitations.py
+++ b/invitations.py
@@ -1,0 +1,28 @@
+"""Invitation and RSVP handling."""
+
+from data_store import events, guests, rsvps
+
+
+def send_invitation(event_id: int, guest_email: str) -> bool:
+    """Mock sending an invitation by email."""
+    event = events.get(event_id)
+    if not event:
+        return False
+    print(f"Sending invitation for '{event['name']}' to {guest_email}")
+    return True
+
+
+def record_rsvp(event_id: int, guest_id: int, response: str) -> bool:
+    """Record a guest's RSVP response."""
+    if response not in {"Ja", "Nein", "Vielleicht"}:
+        raise ValueError("Response must be 'Ja', 'Nein' or 'Vielleicht'")
+    rsvps[(event_id, guest_id)] = response
+    return True
+
+
+def notify_organizer_rsvp(event_id: int, guest_id: int, response: str) -> None:
+    """Notify organizer about a new RSVP."""
+    event = events.get(event_id)
+    guest = guests.get(guest_id)
+    if event and guest:
+        print(f"Organizer notified: {guest['name']} responded '{response}' for '{event['name']}'")

--- a/mobile_apps.py
+++ b/mobile_apps.py
@@ -1,0 +1,16 @@
+"""Mobile app build placeholders."""
+
+
+def build_ios_app() -> None:
+    """Simulate building the iOS app."""
+    print("Building iOS app...")
+
+
+def build_android_app() -> None:
+    """Simulate building the Android app."""
+    print("Building Android app...")
+
+
+def sync_web_mobile(data: dict) -> None:
+    """Simulate syncing data between web and mobile."""
+    print(f"Syncing data: {data}")

--- a/offline.py
+++ b/offline.py
@@ -1,0 +1,15 @@
+"""Offline data handling."""
+
+from data_store import offline_cache
+
+
+def cache_offline_data(user_id: int, data: dict) -> None:
+    """Cache data for offline use."""
+    offline_cache.setdefault(user_id, {}).update(data)
+
+
+def sync_offline_data(user_id: int) -> dict:
+    """Return cached data and clear it to simulate sync."""
+    data = offline_cache.get(user_id, {})
+    offline_cache[user_id] = {}
+    return data

--- a/payments.py
+++ b/payments.py
@@ -1,0 +1,17 @@
+"""Payment processing (mock)."""
+
+from data_store import payments
+
+
+def process_payment(guest_id: int, event_id: int, amount: float, method: str) -> None:
+    """Record a payment for a guest."""
+    payments.setdefault(guest_id, {})[event_id] = {
+        "amount": amount,
+        "method": method,
+        "status": "paid",
+    }
+
+
+def payment_status(guest_id: int, event_id: int) -> str:
+    """Return payment status for a guest."""
+    return payments.get(guest_id, {}).get(event_id, {}).get("status", "unpaid")

--- a/seating.py
+++ b/seating.py
@@ -1,0 +1,26 @@
+"""Seating plan management."""
+
+from data_store import seating_plans
+
+
+def create_seating_plan(event_id: int, seats: int) -> None:
+    """Initialize a seating plan with a given number of seats."""
+    seating_plans[event_id] = {f"S{n}": None for n in range(1, seats + 1)}
+
+
+def select_seat(event_id: int, guest_id: int, seat_id: str) -> bool:
+    """Guest selects a seat if available."""
+    plan = seating_plans.get(event_id)
+    if not plan or seat_id not in plan or plan[seat_id] is not None:
+        return False
+    plan[seat_id] = guest_id
+    return True
+
+
+def assign_seat_manually(event_id: int, guest_id: int, seat_id: str) -> bool:
+    """Organizer assigns a seat, overwriting existing assignment."""
+    plan = seating_plans.get(event_id)
+    if not plan or seat_id not in plan:
+        return False
+    plan[seat_id] = guest_id
+    return True

--- a/security.py
+++ b/security.py
@@ -1,0 +1,12 @@
+"""Security utilities."""
+
+
+def ensure_gdpr_compliance(data: dict) -> bool:
+    """Placeholder GDPR compliance check."""
+    required = {"consent": True}
+    return all(data.get(k) == v for k, v in required.items())
+
+
+def enable_two_factor_auth(user_id: int) -> None:
+    """Mock enabling of 2FA."""
+    print(f"2FA enabled for user {user_id}")

--- a/style.css
+++ b/style.css
@@ -1,0 +1,85 @@
+:root {
+  --primary: #4a90e2;
+  --danger: #e74c3c;
+  --bg: #f9f9f9;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background: var(--bg);
+  color: #333;
+}
+
+.nav {
+  background: var(--primary);
+  color: #fff;
+  padding: 10px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav a {
+  color: #fff;
+  margin-right: 15px;
+  text-decoration: none;
+}
+
+.nav a.active {
+  text-decoration: underline;
+}
+
+.container {
+  max-width: 900px;
+  margin: 20px auto;
+  padding: 0 15px;
+}
+
+.card {
+  background: #fff;
+  padding: 15px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  margin-bottom: 20px;
+}
+
+.form-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.form-row input {
+  flex: 1;
+  padding: 8px;
+}
+
+.btn {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.btn-delete {
+  background: var(--danger);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.table th, .table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid #eee;
+}
+
+.table th {
+  text-align: left;
+  background: #f0f0f0;
+}


### PR DESCRIPTION
## Summary
- add navigation-based UI with dedicated pages for events, guests, and analytics
- implement guest CRUD and analytics endpoints in the Flask backend
- modernize styling and JavaScript for a cleaner, more usable interface

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_689770d4ee4c8325a1916272dde5636d