### PR TITLE
Persist event interactions in database

### DIFF
--- a/analytics.html
+++ b/analytics.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Event Manager</title>
+    <title>Analytics - Event Manager</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -11,15 +11,14 @@
         <div class="nav-links">
             <a href="events.html">Events</a>
             <a href="guests.html">Guests</a>
-            <a href="analytics.html">Analytics</a>
+            <a href="analytics.html" class="active">Analytics</a>
             <a href="login.html">Login</a>
         </div>
     </nav>
-    <main class="container" id="home">
-        <h1>Upcoming Events</h1>
-        <input id="search" type="text" placeholder="Search events..." />
-        <div id="event-tiles" class="tiles"></div>
+    <main class="container">
+        <h1>Analytics</h1>
+        <div id="summary" class="card"></div>
     </main>
-    <script src="index.js"></script>
+    <script src="analytics.js"></script>
 </body>
 </html>

--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,9 @@
+async function loadSummary() {
+  const res = await fetch('/api/analytics');
+  const data = await res.json();
+  const div = document.getElementById('summary');
+  div.innerHTML = `<p><strong>Events:</strong> ${data.events}</p>` +
+                  `<p><strong>Guests:</strong> ${data.guests}</p>`;
+}
+
+loadSummary();

--- a/analytics.py
+++ b/analytics.py
@@ -1,0 +1,44 @@
+"""Analytics and reporting."""
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+from database import SessionLocal
+from models import Guest, RSVP, Payment, Seating
+
+
+def dashboard_overview(event_id: int) -> dict:
+    """Return a simple overview for an event."""
+    session: Session = SessionLocal()
+    total_guests = session.query(Guest).filter(Guest.event_id == event_id).count()
+    responses = {"Ja": 0, "Nein": 0, "Vielleicht": 0}
+    for resp, count in (
+        session.query(RSVP.response, func.count(RSVP.id))
+        .filter(RSVP.event_id == event_id)
+        .group_by(RSVP.response)
+    ):
+        responses[resp] = count
+    paid = (
+        session.query(Payment)
+        .filter(Payment.event_id == event_id, Payment.status == "paid")
+        .count()
+    )
+    session.close()
+    return {
+        "total_guests": total_guests,
+        "responses": responses,
+        "payments": paid,
+    }
+
+
+def generate_report(event_id: int) -> dict:
+    """Generate a detailed report."""
+    overview = dashboard_overview(event_id)
+    session: Session = SessionLocal()
+    seats_assigned = (
+        session.query(Seating)
+        .filter(Seating.event_id == event_id, Seating.guest_id.isnot(None))
+        .count()
+    )
+    session.close()
+    overview["seats_assigned"] = seats_assigned
+    return overview

--- a/app.py
+++ b/app.py
@@ -1,0 +1,214 @@
+from flask import Flask, request, jsonify, send_from_directory, session
+from events import create_event, update_event, delete_event, get_all_events
+from guests import manage_guest, get_all_guests
+from invitations import send_invitation, record_rsvp
+from seating import create_seating_plan, select_seat, assign_seat_manually
+from payments import process_payment, payment_status
+from analytics import dashboard_overview, generate_report
+from feedback import submit_feedback
+from database import SessionLocal
+from models import Event, Guest
+from db_setup import init_db
+from auth import create_user, authenticate_user, request_password_reset, verify_two_factor
+from security import require_roles
+
+app = Flask(__name__, static_url_path='', static_folder='.')
+app.secret_key = "dev-secret"
+
+# Ensure database tables exist on startup
+init_db()
+
+
+@app.route('/')
+def index():
+    """Serve the main HTML page."""
+    return send_from_directory('.', 'index.html')
+
+
+@app.route('/api/events', methods=['GET'])
+def list_events():
+    """Return all events."""
+    return jsonify(get_all_events())
+
+
+@app.route('/api/events', methods=['POST'])
+@require_roles('admin', 'co-organizer')
+def add_event():
+    """Create an event from posted JSON."""
+    data = request.get_json(force=True)
+    event_id = create_event(
+        data.get('name', ''),
+        data.get('date', ''),
+        data.get('time', ''),
+        data.get('location', ''),
+        float(data.get('price', 0)),
+        data.get('program', [])
+    )
+    return jsonify({'id': event_id}), 201
+
+
+@app.route('/api/events/<int:event_id>', methods=['PUT'])
+@require_roles('admin', 'co-organizer')
+def edit_event(event_id: int):
+    """Update an existing event."""
+    updated = update_event(event_id, **request.get_json(force=True))
+    if not updated:
+        return jsonify({'error': 'not found'}), 404
+    return jsonify(updated)
+
+
+@app.route('/api/events/<int:event_id>', methods=['DELETE'])
+@require_roles('admin')
+def remove_event(event_id: int):
+    """Delete the specified event."""
+    if not delete_event(event_id):
+        return jsonify({'error': 'not found'}), 404
+    return '', 204
+
+
+@app.route('/api/guests', methods=['GET'])
+@require_roles('admin', 'co-organizer')
+def list_guests():
+    """Return all guests."""
+    return jsonify(get_all_guests())
+
+
+@app.route('/api/guests', methods=['POST'])
+@require_roles('admin', 'co-organizer')
+def add_guest():
+    """Add a guest."""
+    data = request.get_json(force=True)
+    gid = manage_guest(action='add',
+                       name=data.get('name', ''),
+                       email=data.get('email', ''),
+                       category=data.get('category', ''),
+                       event_id=data.get('event_id'))
+    return jsonify({'id': gid}), 201
+
+
+@app.route('/api/guests/<int:guest_id>', methods=['DELETE'])
+@require_roles('admin')
+def delete_guest(guest_id: int):
+    """Delete a guest."""
+    try:
+        manage_guest(guest_id, action='delete')
+        return '', 204
+    except ValueError:
+        return jsonify({'error': 'not found'}), 404
+
+
+@app.route('/api/analytics', methods=['GET'])
+@require_roles('admin', 'co-organizer')
+def analytics_summary():
+    """Simple analytics overview."""
+    session = SessionLocal()
+    event_count = session.query(Event).count()
+    guest_count = session.query(Guest).count()
+    session.close()
+    return jsonify({'events': event_count, 'guests': guest_count})
+
+
+@app.route('/api/invitations', methods=['POST'])
+@require_roles('admin', 'co-organizer')
+def api_send_invitation():
+    data = request.get_json(force=True)
+    if send_invitation(data['event_id'], data['email']):
+        return jsonify({'status': 'sent'})
+    return jsonify({'error': 'event not found'}), 404
+
+
+@app.route('/api/rsvp', methods=['POST'])
+def api_record_rsvp():
+    data = request.get_json(force=True)
+    record_rsvp(data['event_id'], data['guest_id'], data['response'])
+    return jsonify({'status': 'recorded'})
+
+
+@app.route('/api/seating/plan', methods=['POST'])
+@require_roles('admin', 'co-organizer')
+def api_create_plan():
+    data = request.get_json(force=True)
+    create_seating_plan(data['event_id'], data['seats'])
+    return jsonify({'status': 'created'})
+
+
+@app.route('/api/seating/select', methods=['POST'])
+def api_select_seat():
+    data = request.get_json(force=True)
+    if select_seat(data['event_id'], data['guest_id'], data['seat_id']):
+        return jsonify({'status': 'selected'})
+    return jsonify({'error': 'unavailable'}), 400
+
+
+@app.route('/api/seating/assign', methods=['POST'])
+@require_roles('admin', 'co-organizer')
+def api_assign_seat():
+    data = request.get_json(force=True)
+    if assign_seat_manually(data['event_id'], data['guest_id'], data['seat_id']):
+        return jsonify({'status': 'assigned'})
+    return jsonify({'error': 'invalid seat'}), 400
+
+
+@app.route('/api/payments', methods=['POST'])
+def api_process_payment():
+    data = request.get_json(force=True)
+    process_payment(data['guest_id'], data['event_id'], data['amount'], data.get('method', 'card'))
+    return jsonify({'status': 'paid'})
+
+
+@app.route('/api/payments/<int:guest_id>/<int:event_id>', methods=['GET'])
+def api_payment_status(guest_id: int, event_id: int):
+    return jsonify({'status': payment_status(guest_id, event_id)})
+
+
+@app.route('/api/analytics/<int:event_id>', methods=['GET'])
+@require_roles('admin', 'co-organizer')
+def api_event_report(event_id: int):
+    return jsonify(generate_report(event_id))
+
+
+@app.route('/api/feedback', methods=['POST'])
+def api_feedback():
+    data = request.get_json(force=True)
+    submit_feedback(data['event_id'], data['guest_id'], data['rating'], data.get('comment', ''))
+    return jsonify({'status': 'received'})
+
+
+@app.route('/api/register', methods=['POST'])
+def register():
+    data = request.get_json(force=True)
+    uid = create_user(data['email'], data['password'], data.get('role', 'guest'))
+    return jsonify({'id': uid}), 201
+
+
+@app.route('/api/login', methods=['POST'])
+def login():
+    data = request.get_json(force=True)
+    user = authenticate_user(data['email'], data['password'])
+    if not user:
+        return jsonify({'error': 'invalid credentials'}), 401
+    if user.role == 'admin':
+        otp = data.get('otp')
+        if otp and not verify_two_factor(otp):
+            return jsonify({'error': 'invalid otp'}), 401
+    session['user_id'] = user.id
+    session['role'] = user.role
+    return jsonify({'message': 'logged in'})
+
+
+@app.route('/api/password-reset', methods=['POST'])
+def password_reset():
+    data = request.get_json(force=True)
+    if request_password_reset(data['email']):
+        return jsonify({'message': 'reset sent'})
+    return jsonify({'error': 'not found'}), 404
+
+
+@app.route('/api/logout', methods=['POST'])
+def logout():
+    session.clear()
+    return jsonify({'message': 'logged out'})
+
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080, debug=True)

--- a/auth.py
+++ b/auth.py
@@ -1,0 +1,47 @@
+"""User authentication helpers."""
+
+from typing import Optional
+from werkzeug.security import generate_password_hash, check_password_hash
+from sqlalchemy.orm import Session
+from database import SessionLocal
+from models import User
+
+
+def create_user(email: str, password: str, role: str) -> int:
+    """Register a new user and return its id."""
+    session: Session = SessionLocal()
+    user = User(email=email, password_hash=generate_password_hash(password), role=role)
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    uid = user.id
+    session.close()
+    return uid
+
+
+def authenticate_user(email: str, password: str) -> Optional[User]:
+    """Return user if credentials are valid."""
+    session: Session = SessionLocal()
+    user = session.query(User).filter(User.email == email).first()
+    if user and check_password_hash(user.password_hash, password):
+        session.expunge(user)
+        session.close()
+        return user
+    session.close()
+    return None
+
+
+def request_password_reset(email: str) -> bool:
+    """Placeholder password reset implementation."""
+    session: Session = SessionLocal()
+    user = session.query(User).filter(User.email == email).first()
+    session.close()
+    if not user:
+        return False
+    print(f"Password reset link sent to {email}")
+    return True
+
+
+def verify_two_factor(code: str) -> bool:
+    """Mock verification of a 2FA code."""
+    return code == "123456"

--- a/communication.py
+++ b/communication.py
@@ -1,0 +1,40 @@
+"""Communication utilities."""
+
+from sqlalchemy.orm import Session
+from database import SessionLocal
+from models import Guest
+
+
+def send_message(recipient_ids, subject: str, body: str) -> None:
+    """Send a message to recipients (mock)."""
+    session: Session = SessionLocal()
+    if recipient_ids == "all":
+        recipients = session.query(Guest).all()
+    else:
+        recipients = session.query(Guest).filter(Guest.id.in_(recipient_ids)).all()
+    for r in recipients:
+        print(f"To {r.email}: {subject}\n{body}\n")
+    session.close()
+
+
+def push_notification(guest_id: int, message: str) -> bool:
+    """Send a push notification (mock)."""
+    session: Session = SessionLocal()
+    guest = session.get(Guest, guest_id)
+    if not guest:
+        session.close()
+        return False
+    print(f"Push to {guest.name}: {message}")
+    session.close()
+    return True
+
+
+def send_reminder(event_id: int, guest_id: int = None) -> None:
+    """Send reminder emails. If guest_id is None, send to all guests."""
+    session: Session = SessionLocal()
+    query = session.query(Guest)
+    if guest_id:
+        query = query.filter(Guest.id == guest_id)
+    for g in query.all():
+        print(f"Reminder sent to {g.email} for event {event_id}")
+    session.close()

--- a/data_store.py
+++ b/data_store.py
@@ -1,0 +1,4 @@
+"""Lightweight in-memory store for offline cache."""
+
+# Offline cache keyed by user_id
+offline_cache: dict = {}

--- a/database.py
+++ b/database.py
@@ -1,0 +1,10 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///events.db")
+
+engine = create_engine(DATABASE_URL, future=True)
+SessionLocal = sessionmaker(bind=engine, expire_on_commit=False)
+
+Base = declarative_base()

--- a/db_setup.py
+++ b/db_setup.py
@@ -1,0 +1,13 @@
+"""Create database tables for the event management app."""
+
+from database import engine, Base
+import models  # noqa: F401 to register models
+
+
+def init_db():
+    Base.metadata.create_all(bind=engine)
+
+
+if __name__ == "__main__":
+    init_db()
+    print("Database initialized.")

--- a/events.html
+++ b/events.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Events - Event Manager</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="nav">
+        <a href="index.html" class="nav-brand">Event Manager</a>
+        <div class="nav-links">
+            <a href="events.html" class="active">Events</a>
+            <a href="guests.html">Guests</a>
+            <a href="analytics.html">Analytics</a>
+            <a href="login.html">Login</a>
+        </div>
+    </nav>
+    <main class="container">
+        <h1>Events</h1>
+        <form id="event-form" class="card">
+            <div class="form-row">
+                <input type="text" id="name" placeholder="Event Name" required>
+                <input type="date" id="date" required>
+                <input type="time" id="time" required>
+            </div>
+            <div class="form-row">
+                <input type="text" id="location" placeholder="Location" required>
+                <input type="number" id="price" placeholder="Price" step="0.01">
+                <input type="text" id="program" placeholder="Program (comma separated)">
+            </div>
+            <button type="submit" class="btn">Create Event</button>
+        </form>
+        <table id="events-table" class="table">
+            <thead>
+                <tr>
+                    <th>Name</th><th>Date</th><th>Time</th><th>Location</th><th>Price</th><th>Program</th><th></th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </main>
+    <script src="events.js"></script>
+</body>
+</html>

--- a/events.js
+++ b/events.js
@@ -1,0 +1,47 @@
+async function fetchEvents() {
+  const res = await fetch('/api/events');
+  const data = await res.json();
+  const tbody = document.querySelector('#events-table tbody');
+  tbody.innerHTML = '';
+  data.forEach(ev => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${ev.name}</td>
+      <td>${ev.date}</td>
+      <td>${ev.time}</td>
+      <td>${ev.location}</td>
+      <td>${Number(ev.price).toFixed(2)}</td>
+      <td>${(ev.program || []).join(', ')}</td>
+      <td><button data-id="${ev.id}" class="btn btn-delete">Delete</button></td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+document.getElementById('event-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const payload = {
+    name: document.getElementById('name').value,
+    date: document.getElementById('date').value,
+    time: document.getElementById('time').value,
+    location: document.getElementById('location').value,
+    price: parseFloat(document.getElementById('price').value || 0),
+    program: document.getElementById('program').value.split(',').map(p => p.trim()).filter(Boolean)
+  };
+  await fetch('/api/events', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  });
+  e.target.reset();
+  fetchEvents();
+});
+
+document.querySelector('#events-table').addEventListener('click', async (e) => {
+  if (e.target.classList.contains('btn-delete')) {
+    const id = e.target.getAttribute('data-id');
+    await fetch(`/api/events/${id}`, {method: 'DELETE'});
+    fetchEvents();
+  }
+});
+
+fetchEvents();

--- a/events.py
+++ b/events.py
@@ -1,0 +1,73 @@
+"""Event management functions backed by SQLAlchemy."""
+
+from typing import List, Dict
+from sqlalchemy.orm import Session
+from database import SessionLocal
+from models import Event
+
+
+def _event_to_dict(event: Event) -> Dict:
+    return {
+        "id": event.id,
+        "name": event.name,
+        "date": event.date,
+        "time": event.time,
+        "location": event.location,
+        "price": event.price,
+        "program": event.program.split("|") if event.program else [],
+    }
+
+
+def create_event(name: str, date: str, time: str, location: str, price: float,
+                 program_points: List[str]) -> int:
+    """Create a new event and return its id."""
+    session: Session = SessionLocal()
+    event = Event(name=name, date=date, time=time,
+                  location=location, price=price,
+                  program="|".join(program_points))
+    session.add(event)
+    session.commit()
+    session.refresh(event)
+    event_id = event.id
+    session.close()
+    return event_id
+
+
+def update_event(event_id: int, **changes) -> Dict | None:
+    """Update fields of an existing event. Return updated dict or None."""
+    session: Session = SessionLocal()
+    event = session.get(Event, event_id)
+    if not event:
+        session.close()
+        return None
+    for key, value in changes.items():
+        if hasattr(event, key):
+            if key == "program" and isinstance(value, list):
+                value = "|".join(value)
+            setattr(event, key, value)
+    session.commit()
+    session.refresh(event)
+    data = _event_to_dict(event)
+    session.close()
+    return data
+
+
+def delete_event(event_id: int) -> bool:
+    """Delete an event by its id."""
+    session: Session = SessionLocal()
+    event = session.get(Event, event_id)
+    if not event:
+        session.close()
+        return False
+    session.delete(event)
+    session.commit()
+    session.close()
+    return True
+
+
+def get_all_events() -> List[Dict]:
+    """Return all events as a list of dictionaries."""
+    session: Session = SessionLocal()
+    data = [_event_to_dict(e) for e in session.query(Event).all()]
+    session.close()
+    return data

--- a/feedback.py
+++ b/feedback.py
@@ -1,0 +1,19 @@
+"""Feedback and surveys backed by the database."""
+
+from sqlalchemy.orm import Session
+from database import SessionLocal
+from models import Feedback
+
+
+def submit_feedback(event_id: int, guest_id: int, rating: int, comment: str) -> None:
+    """Store feedback from a guest."""
+    session: Session = SessionLocal()
+    entry = Feedback(event_id=event_id, guest_id=guest_id, rating=rating, comment=comment)
+    session.add(entry)
+    session.commit()
+    session.close()
+
+
+def track_survey(event_id: int, question: str, answers: dict) -> dict:
+    """Return survey data for analysis (mock)."""
+    return {"event_id": event_id, "question": question, "answers": answers}

--- a/guests.html
+++ b/guests.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Guests - Event Manager</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="nav">
+        <a href="index.html" class="nav-brand">Event Manager</a>
+        <div class="nav-links">
+            <a href="events.html">Events</a>
+            <a href="guests.html" class="active">Guests</a>
+            <a href="analytics.html">Analytics</a>
+            <a href="login.html">Login</a>
+        </div>
+    </nav>
+    <main class="container">
+        <h1>Guests</h1>
+        <form id="guest-form" class="card">
+            <div class="form-row">
+                <input type="text" id="g-name" placeholder="Name" required>
+                <input type="email" id="g-email" placeholder="Email" required>
+                <input type="text" id="g-category" placeholder="Category">
+                <input type="number" id="g-event" placeholder="Event ID">
+            </div>
+            <button type="submit" class="btn">Add Guest</button>
+        </form>
+        <table id="guests-table" class="table">
+            <thead>
+                <tr>
+                    <th>Name</th><th>Email</th><th>Category</th><th>Event</th><th></th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+    </main>
+    <script src="guests.js"></script>
+</body>
+</html>

--- a/guests.js
+++ b/guests.js
@@ -1,0 +1,43 @@
+async function fetchGuests() {
+  const res = await fetch('/api/guests');
+  const data = await res.json();
+  const tbody = document.querySelector('#guests-table tbody');
+  tbody.innerHTML = '';
+  data.forEach(g => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `
+      <td>${g.name}</td>
+      <td>${g.email}</td>
+      <td>${g.category || ''}</td>
+      <td>${g.event_id || ''}</td>
+      <td><button data-id="${g.id}" class="btn btn-delete">Delete</button></td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+document.getElementById('guest-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const payload = {
+    name: document.getElementById('g-name').value,
+    email: document.getElementById('g-email').value,
+    category: document.getElementById('g-category').value,
+    event_id: parseInt(document.getElementById('g-event').value || '0') || null
+  };
+  await fetch('/api/guests', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  });
+  e.target.reset();
+  fetchGuests();
+});
+
+document.querySelector('#guests-table').addEventListener('click', async (e) => {
+  if (e.target.classList.contains('btn-delete')) {
+    const id = e.target.getAttribute('data-id');
+    await fetch(`/api/guests/${id}`, {method: 'DELETE'});
+    fetchGuests();
+  }
+});
+
+fetchGuests();

--- a/guests.py
+++ b/guests.py
@@ -1,0 +1,103 @@
+"""Guest list management backed by SQLAlchemy."""
+
+import csv
+from typing import Dict, List
+from sqlalchemy.orm import Session
+from database import SessionLocal
+from models import Guest
+
+
+def _guest_to_dict(guest: Guest) -> Dict:
+    return {
+        "id": guest.id,
+        "name": guest.name,
+        "email": guest.email,
+        "category": guest.category,
+        "event_id": guest.event_id,
+    }
+
+
+def manage_guest(guest_id: int = None, action: str = "add", **data) -> int:
+    """Add, update or delete a guest. Optionally assign to an event."""
+    session: Session = SessionLocal()
+    if action == "add":
+        guest = Guest(name=data.get("name"), email=data.get("email"), category=data.get("category"),
+                      event_id=data.get("event_id"))
+        session.add(guest)
+        session.commit()
+        session.refresh(guest)
+        gid = guest.id
+        session.close()
+        return gid
+    elif action == "edit":
+        guest = session.get(Guest, guest_id)
+        if not guest:
+            session.close()
+            raise ValueError("Invalid action or guest_id")
+        for key, value in data.items():
+            if hasattr(guest, key):
+                setattr(guest, key, value)
+        session.commit()
+        gid = guest.id
+        session.close()
+        return gid
+    elif action == "delete":
+        guest = session.get(Guest, guest_id)
+        if not guest:
+            session.close()
+            raise ValueError("Invalid action or guest_id")
+        session.delete(guest)
+        session.commit()
+        session.close()
+        return guest_id
+    else:
+        session.close()
+        raise ValueError("Invalid action or guest_id")
+
+
+def categorize_guest(guest_id: int, category: str) -> bool:
+    """Assign a category to a guest."""
+    session: Session = SessionLocal()
+    guest = session.get(Guest, guest_id)
+    if not guest:
+        session.close()
+        return False
+    guest.category = category
+    session.commit()
+    session.close()
+    return True
+
+
+def assign_guest_to_event(guest_id: int, event_id: int) -> bool:
+    """Assign an existing guest to an event."""
+    session: Session = SessionLocal()
+    guest = session.get(Guest, guest_id)
+    if not guest:
+        session.close()
+        return False
+    guest.event_id = event_id
+    session.commit()
+    session.close()
+    return True
+
+
+def import_guestlist(csv_file: str) -> int:
+    """Import guests from a CSV file. Columns: name,email,category"""
+    count = 0
+    with open(csv_file, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            manage_guest(action="add", name=row.get("name"), email=row.get("email"), category=row.get("category"))
+            count += 1
+    return count
+
+
+def get_all_guests(event_id: int | None = None) -> List[Dict]:
+    """Return all guests as a list of dictionaries. Filter by event if provided."""
+    session: Session = SessionLocal()
+    query = session.query(Guest)
+    if event_id is not None:
+        query = query.filter(Guest.event_id == event_id)
+    data = [_guest_to_dict(g) for g in query.all()]
+    session.close()
+    return data

--- a/index.js
+++ b/index.js
@@ -1,0 +1,22 @@
+async function loadEvents() {
+  const res = await fetch('/api/events');
+  const events = await res.json();
+  const container = document.getElementById('event-tiles');
+  container.innerHTML = '';
+  events.forEach(ev => {
+    const tile = document.createElement('div');
+    tile.className = 'tile';
+    tile.innerHTML = `<h3>${ev.name}</h3><p>${ev.date} ${ev.time}</p><p>${ev.location}</p>`;
+    container.appendChild(tile);
+  });
+}
+
+function filterEvents() {
+  const term = document.getElementById('search').value.toLowerCase();
+  document.querySelectorAll('.tile').forEach(tile => {
+    tile.style.display = tile.textContent.toLowerCase().includes(term) ? '' : 'none';
+  });
+}
+
+document.getElementById('search').addEventListener('input', filterEvents);
+loadEvents();

--- a/invitations.py
+++ b/invitations.py
@@ -1,0 +1,43 @@
+"""Invitation and RSVP handling using the database."""
+
+from sqlalchemy.orm import Session
+from database import SessionLocal
+from models import Event, Guest, RSVP
+
+
+def send_invitation(event_id: int, guest_email: str) -> bool:
+    """Mock sending an invitation by email."""
+    session: Session = SessionLocal()
+    event = session.get(Event, event_id)
+    session.close()
+    if not event:
+        return False
+    print(f"Sending invitation for '{event.name}' to {guest_email}")
+    return True
+
+
+def record_rsvp(event_id: int, guest_id: int, response: str) -> bool:
+    """Record a guest's RSVP response in the database."""
+    if response not in {"Ja", "Nein", "Vielleicht"}:
+        raise ValueError("Response must be 'Ja', 'Nein' or 'Vielleicht'")
+    session: Session = SessionLocal()
+    rsvp = session.query(RSVP).filter_by(event_id=event_id, guest_id=guest_id).first()
+    if rsvp:
+        rsvp.response = response
+    else:
+        rsvp = RSVP(event_id=event_id, guest_id=guest_id, response=response)
+        session.add(rsvp)
+    session.commit()
+    session.close()
+    notify_organizer_rsvp(event_id, guest_id, response)
+    return True
+
+
+def notify_organizer_rsvp(event_id: int, guest_id: int, response: str) -> None:
+    """Notify organizer about a new RSVP (mock)."""
+    session: Session = SessionLocal()
+    event = session.get(Event, event_id)
+    guest = session.get(Guest, guest_id)
+    if event and guest:
+        print(f"Organizer notified: {guest.name} responded '{response}' for '{event.name}'")
+    session.close()

--- a/login.html
+++ b/login.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Login - Event Manager</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <nav class="nav">
+        <a href="index.html" class="nav-brand">Event Manager</a>
+        <div class="nav-links">
+            <a href="index.html">Home</a>
+            <a href="events.html">Events</a>
+            <a href="guests.html">Guests</a>
+            <a href="analytics.html">Analytics</a>
+        </div>
+    </nav>
+    <main class="container">
+        <h1>Login</h1>
+        <form id="login-form" class="card">
+            <div class="form-row">
+                <input type="email" id="email" placeholder="Email" required>
+                <input type="password" id="password" placeholder="Password" required>
+                <input type="text" id="otp" placeholder="OTP (optional)">
+            </div>
+            <button type="submit" class="btn">Login</button>
+        </form>
+        <div id="login-msg"></div>
+    <h2>Register</h2>
+    <form id="register-form" class="card">
+        <div class="form-row">
+            <input type="email" id="reg-email" placeholder="Email" required>
+            <input type="password" id="reg-password" placeholder="Password" required>
+            <select id="reg-role">
+                <option value="guest">Guest</option>
+                <option value="co-organizer">Co-Organisator</option>
+                <option value="admin">Admin</option>
+            </select>
+        </div>
+        <button type="submit" class="btn">Register</button>
+    </form>
+    <div id="register-msg"></div>
+    </main>
+    <script src="login.js"></script>
+</body>
+</html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,46 @@
+async function doLogin(e) {
+  e.preventDefault();
+  const payload = {
+    email: document.getElementById('email').value,
+    password: document.getElementById('password').value,
+    otp: document.getElementById('otp').value
+  };
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  });
+  const msgDiv = document.getElementById('login-msg');
+  if (res.ok) {
+    msgDiv.textContent = 'Login successful';
+    window.location.href = 'index.html';
+  } else {
+    const data = await res.json();
+    msgDiv.textContent = data.error || 'Login failed';
+  }
+}
+
+document.getElementById('login-form').addEventListener('submit', doLogin);
+
+async function doRegister(e) {
+  e.preventDefault();
+  const payload = {
+    email: document.getElementById('reg-email').value,
+    password: document.getElementById('reg-password').value,
+    role: document.getElementById('reg-role').value
+  };
+  const res = await fetch('/api/register', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify(payload)
+  });
+  const msgDiv = document.getElementById('register-msg');
+  if (res.ok) {
+    msgDiv.textContent = 'Registration successful';
+  } else {
+    const data = await res.json();
+    msgDiv.textContent = data.error || 'Registration failed';
+  }
+}
+
+document.getElementById('register-form').addEventListener('submit', doRegister);

--- a/mobile_apps.py
+++ b/mobile_apps.py
@@ -1,0 +1,16 @@
+"""Mobile app build placeholders."""
+
+
+def build_ios_app() -> None:
+    """Simulate building the iOS app."""
+    print("Building iOS app...")
+
+
+def build_android_app() -> None:
+    """Simulate building the Android app."""
+    print("Building Android app...")
+
+
+def sync_web_mobile(data: dict) -> None:
+    """Simulate syncing data between web and mobile."""
+    print(f"Syncing data: {data}")

--- a/models.py
+++ b/models.py
@@ -1,0 +1,72 @@
+"""Database models for the event management tool."""
+
+from sqlalchemy import Column, Integer, String, Float, Text, ForeignKey, UniqueConstraint
+from database import Base
+
+
+class Event(Base):
+    __tablename__ = "events"
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+    date = Column(String)
+    time = Column(String)
+    location = Column(String)
+    price = Column(Float)
+    program = Column(Text)
+
+
+class Guest(Base):
+    __tablename__ = "guests"
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    email = Column(String)
+    category = Column(String)
+    event_id = Column(Integer, ForeignKey("events.id"))
+
+
+class RSVP(Base):
+    __tablename__ = "rsvps"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    guest_id = Column(Integer, ForeignKey("guests.id"))
+    response = Column(String)
+    __table_args__ = (UniqueConstraint("event_id", "guest_id"),)
+
+
+class Seating(Base):
+    __tablename__ = "seating"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    seat_id = Column(String)
+    guest_id = Column(Integer, ForeignKey("guests.id"), nullable=True)
+    __table_args__ = (UniqueConstraint("event_id", "seat_id"),)
+
+
+class Payment(Base):
+    __tablename__ = "payments"
+    id = Column(Integer, primary_key=True)
+    guest_id = Column(Integer, ForeignKey("guests.id"))
+    event_id = Column(Integer, ForeignKey("events.id"))
+    amount = Column(Float)
+    method = Column(String)
+    status = Column(String)
+
+
+class Feedback(Base):
+    __tablename__ = "feedback"
+    id = Column(Integer, primary_key=True)
+    event_id = Column(Integer, ForeignKey("events.id"))
+    guest_id = Column(Integer, ForeignKey("guests.id"))
+    rating = Column(Integer)
+    comment = Column(Text)
+
+
+class User(Base):
+    """Simple user model with roles and password hash."""
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+    email = Column(String, nullable=False)
+    password_hash = Column(String, nullable=False)
+    role = Column(String, nullable=False)
+
+    __table_args__ = (UniqueConstraint("email"),)

--- a/offline.py
+++ b/offline.py
@@ -1,0 +1,15 @@
+"""Offline data handling."""
+
+from data_store import offline_cache
+
+
+def cache_offline_data(user_id: int, data: dict) -> None:
+    """Cache data for offline use."""
+    offline_cache.setdefault(user_id, {}).update(data)
+
+
+def sync_offline_data(user_id: int) -> dict:
+    """Return cached data and clear it to simulate sync."""
+    data = offline_cache.get(user_id, {})
+    offline_cache[user_id] = {}
+    return data

--- a/payments.py
+++ b/payments.py
@@ -1,0 +1,24 @@
+"""Payment processing backed by the database."""
+
+from sqlalchemy.orm import Session
+from database import SessionLocal
+from models import Payment
+
+
+def process_payment(guest_id: int, event_id: int, amount: float, method: str) -> None:
+    """Record a payment for a guest."""
+    session: Session = SessionLocal()
+    payment = Payment(guest_id=guest_id, event_id=event_id, amount=amount,
+                      method=method, status="paid")
+    session.add(payment)
+    session.commit()
+    session.close()
+
+
+def payment_status(guest_id: int, event_id: int) -> str:
+    """Return payment status for a guest."""
+    session: Session = SessionLocal()
+    payment = session.query(Payment).filter_by(guest_id=guest_id, event_id=event_id).first()
+    status = payment.status if payment else "unpaid"
+    session.close()
+    return status

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+Flask
+SQLAlchemy
+psycopg2-binary
+

--- a/seating.py
+++ b/seating.py
@@ -1,0 +1,40 @@
+"""Seating plan management backed by SQLAlchemy."""
+
+from sqlalchemy.orm import Session
+from database import SessionLocal
+from models import Seating
+
+
+def create_seating_plan(event_id: int, seats: int) -> None:
+    """Initialize a seating plan with a given number of seats."""
+    session: Session = SessionLocal()
+    for n in range(1, seats + 1):
+        session.add(Seating(event_id=event_id, seat_id=f"S{n}"))
+    session.commit()
+    session.close()
+
+
+def select_seat(event_id: int, guest_id: int, seat_id: str) -> bool:
+    """Guest selects a seat if available."""
+    session: Session = SessionLocal()
+    seat = session.query(Seating).filter_by(event_id=event_id, seat_id=seat_id).first()
+    if not seat or seat.guest_id is not None:
+        session.close()
+        return False
+    seat.guest_id = guest_id
+    session.commit()
+    session.close()
+    return True
+
+
+def assign_seat_manually(event_id: int, guest_id: int, seat_id: str) -> bool:
+    """Organizer assigns a seat, overwriting existing assignment."""
+    session: Session = SessionLocal()
+    seat = session.query(Seating).filter_by(event_id=event_id, seat_id=seat_id).first()
+    if not seat:
+        session.close()
+        return False
+    seat.guest_id = guest_id
+    session.commit()
+    session.close()
+    return True

--- a/security.py
+++ b/security.py
@@ -1,0 +1,28 @@
+"""Security utilities and access control helpers."""
+
+from functools import wraps
+from flask import session, abort
+
+
+def ensure_gdpr_compliance(data: dict) -> bool:
+    """Placeholder GDPR compliance check."""
+    required = {"consent": True}
+    return all(data.get(k) == v for k, v in required.items())
+
+
+def enable_two_factor_auth(user_id: int) -> None:
+    """Mock enabling of 2FA."""
+    print(f"2FA enabled for user {user_id}")
+
+
+def require_roles(*roles):
+    """Decorator to limit access to users with given roles."""
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            user_role = session.get("role")
+            if user_role not in roles:
+                abort(403)
+            return func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/style.css
+++ b/style.css
@@ -1,0 +1,97 @@
+:root {
+  --primary: #4a90e2;
+  --danger: #e74c3c;
+  --bg: #f9f9f9;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background: var(--bg);
+  color: #333;
+}
+
+.nav {
+  background: var(--primary);
+  color: #fff;
+  padding: 10px 20px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.nav a {
+  color: #fff;
+  margin-right: 15px;
+  text-decoration: none;
+}
+
+.nav a.active {
+  text-decoration: underline;
+}
+
+.container {
+  max-width: 900px;
+  margin: 20px auto;
+  padding: 0 15px;
+}
+
+.card {
+  background: #fff;
+  padding: 15px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  margin-bottom: 20px;
+}
+
+.form-row {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-bottom: 10px;
+}
+
+.form-row input {
+  flex: 1;
+  padding: 8px;
+}
+
+.btn {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.btn-delete {
+  background: var(--danger);
+}
+
+.table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+.table th, .table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid #eee;
+}
+
+.table th {  
+  text-align: left;
+  background: #f0f0f0;
+}
+
+.tiles {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 15px;
+}
+
+.tile {
+  background: #fff;
+  padding: 15px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}


### PR DESCRIPTION
## Summary
- add registration form for creating user accounts directly from the login page
- make admin OTP entry optional, only verifying when supplied

## Testing
- `venv/bin/python -m py_compile *.py`
- `venv/bin/python - <<'PY'
from app import app
client = app.test_client()
resp = client.post('/api/register', json={'email':'user@example.com','password':'pass','role':'admin'})
print('register', resp.status_code, resp.json)
resp = client.post('/api/login', json={'email':'user@example.com','password':'pass'})
print('login without otp', resp.status_code, resp.json)
resp = client.post('/api/login', json={'email':'user@example.com','password':'pass','otp':'wrong'})
print('login with wrong otp', resp.status_code, resp.json)
resp = client.post('/api/login', json={'email':'user@example.com','password':'pass','otp':'123456'})
print('login with correct otp', resp.status_code, resp.json)
PY`


------
https://chatgpt.com/codex/tasks/task_e_689770d4ee4c8325a1916272dde5636d